### PR TITLE
Small bugfixes and addition of docstrings

### DIFF
--- a/src/spicetools/fastfunc.py
+++ b/src/spicetools/fastfunc.py
@@ -43,7 +43,7 @@ def spkgps(ref: str, obs: int, dummy_lt: bool = True):
         def spkgps_boosted(targ, et):
             _lt = ctypes.c_double()
             _ptarg = empty_double_vector(3)
-            sp.libspice.spkgps_c(targ, et, ref, obs, _ptarg, _lt)
+            sp.libspice.spkgps_c(targ, et, ref, obs, _ptarg, ctypes.byref(_lt))
             return np.frombuffer(_ptarg).copy(), _lt.value
 
     return spkgps_boosted
@@ -96,11 +96,11 @@ def spkcvo(outref: str, refloc: str, abcorr: str, obsctr: str, obsref: str, dumm
             return np.frombuffer(state).copy()
     else:
         def spkcvo_boosted(target, obssta, et):
-            _lt = ctypes.byref(ctypes.c_double())
+            _lt = ctypes.c_double()
             state = empty_double_vector(6)
             sp.libspice.spkcvo_c(
                 target, et, outref, refloc, abcorr, obssta, et,
-                obsctr, obsref, state, _lt
+                obsctr, obsref, state, ctypes.byref(_lt)
             )
             return np.frombuffer(state).copy(), _lt.value
 

--- a/src/spicetools/fastfunc.py
+++ b/src/spicetools/fastfunc.py
@@ -23,10 +23,10 @@ def spkgps(ref: str, obs: int, dummy_lt: bool = True):
     Returns
     -------
     spkgps_boosted : function
-        Boosted spkgps function. Input arguments are `targ` and `et`.
-        - `targ` must be prepared by `ctypes.c_int(int(spkid))`
-        - `et` must be prepared by `ctypes.c_double(et)` (use
-        `timeutil.times2et` with ``return_c=True``).
+        Boosted spkgps function. Input arguments are `targ` and `et` ::
+        - `targ` :  must be prepared by ``ctypes.c_int(int(spkid))``
+        - `et` : must be prepared by ``ctypes.c_double(et)`` (use
+            `timeutil.times2et` with ``return_c=True``).
     """
     ref = str2char_p(ref)
     obs = ctypes.c_int(obs)
@@ -51,6 +51,7 @@ def spkgps(ref: str, obs: int, dummy_lt: bool = True):
 
 def spkcvo(outref: str, refloc: str, abcorr: str, obsctr: str, obsref: str, dummy_lt: bool = True):
     """Return boosted spkcvo function.
+
     Parameters
     ----------
     outref : str
@@ -69,11 +70,12 @@ def spkcvo(outref: str, refloc: str, abcorr: str, obsctr: str, obsref: str, dumm
     Returns
     -------
     spkcvo_boosted : function
-        Boosted spkcvo function. Input arguments are `target`, `obssta`, and `et`.
-        - `target` must be prepared by `str2char_p(str(spkid))`
+        Boosted spkcvo function. Input arguments are `target`, `obssta`, and
+        `et`::
+        - `target` must be prepared by ``str2char_p(str(spkid))``
         - `obssta` must be prepared by ``sp.stypes.to_double_vector(state)``
         - `et` must be prepared by `ctypes.c_double(et)` (use
-        `timeutil.times2et` with ``return_c=True``).
+            `timeutil.times2et` with ``return_c=True``).
     """
     outref = str2char_p(outref)
     refloc = str2char_p(refloc)

--- a/src/spicetools/phase.py
+++ b/src/spicetools/phase.py
@@ -6,6 +6,13 @@ __all__ = ['iau_hg_model']
 
 
 def _hgphi12(alpha__deg):
+    """Compute the phase function coefficients phi1 and phi2.
+
+    Parameters
+    ----------
+    alpha__deg : float or np.ndarray
+        Phase angle in degrees.
+    """
     alpha__rad = alpha__deg*D2R
     sin_a = np.sin(alpha__rad)
     f_a = sin_a/(0.119+1.341*sin_a-0.754*sin_a*sin_a)
@@ -20,6 +27,26 @@ def _hgphi12(alpha__deg):
 
 def iau_hg_model(alpha__deg, gpar=0.15):
     """The IAU HG phase function model in intensity (1 at alpha=0)
+
+    Parameters
+    ----------
+    alpha__deg : float or np.ndarray
+        Phase angle in degrees.
+
+    gpar : float
+        The "slope" G parameter, typically between 0 and 1.
+        Default is 0.15.
+
+    Notes
+    -----
+    The widely used classical HG model for the phase function of asteroids is
+    given by:
+    Bowell, E., Hapke, B., Domingue, D., et al. (1989), "Application of
+    photometric models to asteroids.", in Asteroids II, ed. R. P. Binzel, T.
+    Gehrels, & M. S. Matthews, 524-556
+    An additional discussion can be found in:
+    Myhrvold, N. (2016), PASP, 128, 045004 (Sect. 2.2),
+
     """
     hgphi1, hgphi2 = _hgphi12(np.array(np.abs(alpha__deg)))
     # Just to avoid negative alpha error

--- a/src/spicetools/timeutil.py
+++ b/src/spicetools/timeutil.py
@@ -28,12 +28,16 @@ def times2et(times, return_c=False, **kwargs):
 
     ets_c : list
         List of ET values as ``ctypes.c_double``.
+        Returned only if `return_c` is `True`.
     """
     times = Time(times, **kwargs)
     if return_c:
         ets = []
         ets_c = []
-        for _t in times.iso:
+        times_iso = times.iso
+        if isinstance(times_iso, str):
+            times_iso = [times_iso]
+        for _t in times_iso:
             _et = sp.str2et(_t)
             _etc = ctypes.c_double(_et)
             ets.append(_et)

--- a/src/spicetools/typeutil.py
+++ b/src/spicetools/typeutil.py
@@ -6,8 +6,12 @@ __all__ = ['empty_double_vector', 'str2char_p']
 
 
 def str2char_p(spkid):
-    '''Quick `string_to_char_p` when input is convertible to string.
-    Original code:
+    '''Quick `sp.string_to_char_p` when input is convertible to string.
+
+    Notes
+    -----
+    Original code from spiceypy::
+
     def string_to_char_p(inobject, inlen=None):
         """
         convert a python string to a char_p
@@ -33,7 +37,11 @@ def str2char_p(spkid):
 
 def empty_double_vector(n):
     '''Quick `empty_double_vector` when input is python int.
-    Original code:
+
+    Notes
+    -----
+    Original code from spiceypy::
+
     def empty_double_vector(n):
         if isinstance(n, c_int):
             n = n.value


### PR DESCRIPTION
This PR fixes 2 bugs and 1 docstrings update:

- `timeutils.times2et` can now be properly used for a single time.
- `fastfunc.spkgps` was not working properly when `dummy_lt=False`. 
- add docstrings, especially for `phase.py`

This PR will close #1, close #2, and close #3